### PR TITLE
Fixed python 3.10 Collections module issue

### DIFF
--- a/tenable_jira/utils.py
+++ b/tenable_jira/utils.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 def flatten(d, parent_key='', sep='.'):
     '''
@@ -8,7 +8,7 @@ def flatten(d, parent_key='', sep='.'):
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, collections.abc.MutableMapping):
             items.extend(flatten(v, new_key, sep=sep).items())
         else:
             items.append((new_key, v))


### PR DESCRIPTION
Mutable Mapping is no longer a part of the Collections module and has been moved to Collections.abc.  Deprecated in version 3.3 and now removed in 3.10.
https://docs.python.org/3/library/collections.abc.html
