### PR TITLE
Fix issue type ID overwrite

### DIFF
--- a/tenable_jira/transform.py
+++ b/tenable_jira/transform.py
@@ -41,10 +41,12 @@ class Tio2Jira:
             # with that jira_id.
             if itype['type'] == 'standard':
                 for item in itypes:
-                    if not item['subtask']:
+                    # Check if the name of the remote and config issue types match
+                    # before the ID is changed.
+                    if itype['name'] == item['name']:
                         self.task = {
                             'name': itype['name'],
-                            'jira_id': int(item['id']),
+                            'jira_id': int(itype.get('jira_id', item['id'])),
                             'type': itype['type'],
                             'search': itype['search']
                         }
@@ -54,10 +56,12 @@ class Tio2Jira:
             # with that jira_id.
             elif itype['type'] == 'subtask':
                 for item in itypes:
-                    if item['subtask']:
+                    # Check if the name of the remote and config issue types match
+                    # before the ID is changed.
+                    if itype['name'] == item['name']:
                         self.subtask = {
                             'name': itype['name'],
-                            'jira_id': int(item['id']),
+                            'jira_id': int(itype.get('jira_id', item['id'])),
                             'type': itype['type'],
                             'search': itype['search']
                         }


### PR DESCRIPTION
In the event a Jira project has more than one standard issue type defined but the local config file only has one, the code would overwite the correct jira ID with the wrong one resulting in errors where custom fields don't exist on screens. 

This fix aims to resolve that by comparing the name of the issue type in the config file with the issue type from remote. Additionally it will only take the remote ID when there isn't one defined in the config file. 