### PR TITLE
Support numeric custom fields

### DIFF
--- a/tenable_jira/transform.py
+++ b/tenable_jira/transform.py
@@ -316,6 +316,10 @@ class Tio2Jira:
                         processed = arrow.get(int(value)).format(
                             'YYYY-MM-DDTHH:mm:ss.SSSZ')
 
+                # Cast to float for numeric fields
+                elif f['type'] in ['float']:
+                    processed = float(value)
+
                 # For anything else, just pass through
                 else:
                     processed = value


### PR DESCRIPTION
JIRA validates the incoming data for a [numeric custom field](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-post) and will refuse string input. This PR adds support for numeric custom fields via a simple cast.