### PR TITLE
Corrected Tag Space Issue #253

### DIFF
--- a/tenb2jira/tenable/generators.py
+++ b/tenb2jira/tenable/generators.py
@@ -52,9 +52,12 @@ def tvm_merged_data(assets_iter: 'ExportsIterator',
     # other asset attributes available within the finding for the Jira ticket
     # without build a database to match everything up into.
     assets = {}
+    def spf(value: str) -> str:
+        return value.replace(' ', '_')
     for asset in assets_iter:
         assets[asset['id']] = {
-            'tags': [f'{t["key"]}:{t["value"]}' for t in asset['tags']],
+            'tags': [f'{spf(t["key"])}:{spf(t["value"])}'
+                     for t in asset['tags']],
             'ipv4': asset['ipv4s'],
             'ipv6': asset['ipv6s'],
         }

--- a/tenb2jira/version.py
+++ b/tenb2jira/version.py
@@ -1,1 +1,1 @@
-version = '2.0.1'
+version = '2.0.2'

--- a/tests/tenable/test_generators.py
+++ b/tests/tenable/test_generators.py
@@ -22,7 +22,7 @@ def tvm_assets():
                     'value': 'Illinois',
                 },
                 {
-                    'key': 'Test',
+                    'key': 'Test Value',
                     'value': 'Something'
                 }
             ],
@@ -150,7 +150,9 @@ def test_tvm_merged_data(tvm_assets, tvm_finding):
                                     )
     finding = next(tvm_generator)
     assert finding['asset.uuid'] == '7f68f334-17ba-4ba0-b057-b77ddd783e60'
-    assert finding['asset.tags'] == ['Location:Illinois', 'Test:Something']
+    assert finding['asset.tags'] == ['Location:Illinois',
+                                     'Test_Value:Something'
+                                     ]
     assert finding['integration_finding_id'] == test_uuid
     assert finding['integration_pid_updated'] == pmoddate
     assert finding['asset.test'] == 'value'


### PR DESCRIPTION
Added tag category && value transform to convert spaces into underscores to work with the Jira Cloud label limitations.  This is a re-implementation of #223.