### PR TITLE
Jira’s API Docs are incorrect

### DIFF
--- a/tenb2jira/models.py
+++ b/tenb2jira/models.py
@@ -15,7 +15,7 @@ class TaskMap(Base):
     plugin_id: Mapped[int] = mapped_column(primary_key=True,
                                            sqlite_on_conflict_unique='IGNORE'
                                            )
-    jira_id: Mapped[int]
+    jira_id: Mapped[str]
     updated: Mapped[datetime]
     subtasks: Mapped[List["SubTaskMap"]] = relationship(
         back_populates="task", cascade="all, delete-orphan"
@@ -28,7 +28,7 @@ class SubTaskMap(Base):
                                              sqlite_on_conflict_unique='IGNORE'
                                              )
     asset_id: Mapped[UUID]
-    jira_id: Mapped[int]
+    jira_key: Mapped[str]
     plugin_id: Mapped[int] = mapped_column(ForeignKey('task.plugin_id'))
     is_open: Mapped[bool]
     updated: Mapped[datetime]
@@ -37,14 +37,14 @@ class SubTaskMap(Base):
     def __init__(self,
                  finding_id: str,
                  asset_id: str,
-                 jira_id: int,
+                 jira_id: str,
                  plugin_id: int,
                  is_open: bool = True,
                  **kwargs,
                  ):
         self.finding_id = UUID(finding_id)
         self.asset_id = UUID(asset_id)
-        self.jira_id = int(jira_id)
+        self.jira_id = str(jira_id)
         self.plugin_id = int(plugin_id)
         self.is_open = bool(is_open)
         super().__init__(**kwargs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,11 +7,11 @@ from tenb2jira.models import TaskMap, SubTaskMap
 def test_taskmap():
     now = datetime.datetime.now()
     obj = TaskMap(plugin_id=1,
-                  jira_id=1,
+                  jira_id='VULN-1',
                   updated=now
                   )
     assert obj.plugin_id == 1
-    assert obj.jira_id == 1
+    assert obj.jira_id == 'VULN-1'
     assert obj.updated == now
 
 
@@ -21,7 +21,7 @@ def test_subtaskmap():
     now = datetime.datetime.now()
     obj = SubTaskMap(finding_id=fid,
                      asset_id=aid,
-                     jira_id=1,
+                     jira_id='VULN-1',
                      plugin_id=1,
                      is_open=True,
                      updated=now
@@ -30,18 +30,18 @@ def test_subtaskmap():
     assert obj.finding_id == UUID(fid)
     assert obj.asset_id == UUID(aid)
     assert obj.plugin_id == 1
-    assert obj.jira_id == 1
+    assert obj.jira_id == 'VULN-1'
     assert obj.is_open == True
 
 
 def test_asdict():
     now = datetime.datetime.now()
     obj = TaskMap(plugin_id=1,
-                  jira_id=1,
+                  jira_id='VULN-1',
                   updated=now
                   )
     assert obj.asdict() == {
         'plugin_id': 1,
-        'jira_id': 1,
+        'jira_id': 'VULN-1',
         'updated': now
     }


### PR DESCRIPTION
This shoudl address #257, #258, and #259.  The issue seems to be related to the API docs referring to “issue id OR key” when in reality it only seems to update on the issue key.  Refactored the code to use the issue keys instead of the numerical IDs, and updating seems to be occuring as expected.

https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put