### PR TITLE
Exception in subtask upsert was hidden by multi-threading #262

### DIFF
--- a/tenb2jira/models.py
+++ b/tenb2jira/models.py
@@ -28,7 +28,7 @@ class SubTaskMap(Base):
                                              sqlite_on_conflict_unique='IGNORE'
                                              )
     asset_id: Mapped[UUID]
-    jira_key: Mapped[str]
+    jira_id: Mapped[str]
     plugin_id: Mapped[int] = mapped_column(ForeignKey('task.plugin_id'))
     is_open: Mapped[bool]
     updated: Mapped[datetime]

--- a/tenb2jira/version.py
+++ b/tenb2jira/version.py
@@ -1,1 +1,1 @@
-version = '2.0.4'
+version = '2.0.5'


### PR DESCRIPTION
The SubTask upsert method was failing do to the mapping change from 2.0.4, however was masked because this was occuring within a worker thread.  Corrected the issue, Added logic to only use threading when the max_workers is above 1 (for testing), and also added a failsafe to stop execution after processing findings if the number of observed exceptions from the worker jobs is above 0.

This seems to be related to the bugfix that attempted to correct #257, #258, #259